### PR TITLE
(updated) Runtime optimizations, computePairs unification and batch parallelization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Makefile
 test
 test/inputs.ipynb
 test/test.ipynb
+out
+.cache/clangd/index

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 project(BettiMatching)
 
 find_package(pybind11 REQUIRED)
+find_package(Threads REQUIRED)
 
 pybind11_add_module(betti_matching
     src/_BettiMatching.cpp
@@ -74,3 +75,7 @@ CXX_EXTENSIONS OFF
 )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+
+target_link_libraries(BettiMatching Threads::Threads)

--- a/src/_BettiMatching.cpp
+++ b/src/_BettiMatching.cpp
@@ -3,28 +3,58 @@
 #include "data_structures.h"
 #include "BettiMatching.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <future>
+#include <iostream>
+#include <iterator>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
-#include <cassert>
-#include <utility>
 #include <string>
+#include <tuple>
+#include <utility>
 
 using namespace std;
 namespace py = pybind11;
 
+struct BettiMatchingResult {
+    py::array_t<int64_t> predictionMatchesBirthCoordinates;
+    py::array_t<int64_t> predictionMatchesDeathCoordinates;
+    py::array_t<int64_t> targetMatchesBirthCoordinates;
+    py::array_t<int64_t> targetMatchesDeathCoordinates;
+    py::array_t<int64_t> predictionUnmatchedBirthCoordinates;
+    py::array_t<int64_t> predictionUnmatchedDeathCoordinates;
+    py::array_t<int64_t> numMatchesByDim;
+    py::array_t<int64_t> numUnmatchedPredictionByDim;
+};
 
-
-string repr_vector(const vector<index_t> shape) {
+string repr_vector(const vector<index_t> shape, std::tuple<string, string> parentheses = make_tuple("(", ")"), string separator = ", ") {
     stringstream out_stream;
-    out_stream << "(";
-    for_each(shape.begin(), std::prev(shape.end()), [&out_stream, &shape](auto size)
-                { out_stream << std::to_string(size) << ", "; });
-    out_stream << shape[shape.size() - 1] << ")";
+    out_stream << std::get<0>(parentheses);
+    for_each(shape.begin(), std::prev(shape.end()), [&out_stream, &shape, &separator](auto size)
+                { out_stream << std::to_string(size) << separator; });
+    out_stream << shape[shape.size() - 1] << std::get<1>(parentheses);
     return out_stream.str();
 };
 
+std::tuple<vector<vector<VoxelMatch>>, vector<vector<VoxelPair>>, vector<vector<VoxelPair>>> computeMatchingFromNumpyArrays(
+    py::array_t<value_t> &input0, py::array_t<value_t> &input1)
+{
+    vector<index_t> shape0(input0.shape(), input0.shape() + input0.ndim());
+    vector<index_t> shape1(input1.shape(), input1.shape() + input1.ndim());
+    if (shape0 != shape1) {
+        throw invalid_argument("The shapes of the input volumes must agree. Got " + repr_vector(shape0) + " and " + repr_vector(shape1));
+    }
+    vector<value_t> input0Vector(input0.mutable_data(), input0.mutable_data() + input0.size());
+    vector<value_t> input1Vector(input1.mutable_data(), input1.mutable_data() + input1.size());
 
+    Config config;
+    BettiMatching bettiMatching(std::move(input0Vector), std::move(input1Vector), std::move(shape0), std::move(config));
+    bettiMatching.computeMatching();
+    return bettiMatching.getMatching();
+};
 
 PYBIND11_MODULE(betti_matching, m) {
     py::class_<BettiMatching>(m, "BettiMatching")
@@ -69,38 +99,108 @@ PYBIND11_MODULE(betti_matching, m) {
         .def("get_unmatched_cycle", &BettiMatching::getUnmatchedRepresentativeCycle);
 
 
-    m.def("compute_matching", [](py::array_t<value_t>& input0, py::array_t<value_t>& input1) {
-        vector<index_t> shape0(input0.shape(), input0.shape() + input0.ndim());
-        vector<index_t> shape1(input1.shape(), input1.shape() + input1.ndim());
-        if (shape0 != shape1) {
-            throw invalid_argument("The shapes of the tree input volumes must agree. Got " + repr_vector(shape0)
-                                    + " and " + repr_vector(shape1));
+    m.def("compute_matching", &computeMatchingFromNumpyArrays);
+
+    m.def("compute_matching", [](
+        vector<py::array_t<value_t>> inputs0,
+        vector<py::array_t<value_t>> inputs1
+    )
+    {
+        if (inputs0.size() != inputs1.size()) {
+            throw invalid_argument("Different numbers of inputs where provided: " + std::to_string(inputs0.size()) + " (inputs0) and " + std::to_string(inputs1.size()) + " (inputs1)");
         }
-        vector<value_t> input0Vector(input0.mutable_data(), input0.mutable_data() + input0.size());
-        vector<value_t> input1Vector(input1.mutable_data(), input1.mutable_data() + input1.size());
-        Config config;
-        BettiMatching BM(std::move(input0Vector), std::move(input1Vector), std::move(shape0), std::move(config));
-        BM.computeMatching();
-        return BM.getMatching();
+        size_t batchSize = inputs0.size();
+        size_t numDimensions = inputs0[0].ndim();
+
+        // Create one asynchronous task for Betti matching computation per input in the batch
+        std::vector<std::future<std::tuple<vector<vector<VoxelMatch>>, vector<vector<VoxelPair>>, vector<vector<VoxelPair>>>>> resultFutures;
+        for (int i = 0; i < inputs0.size(); i++) {
+            resultFutures.push_back(std::async(computeMatchingFromNumpyArrays, std::ref(inputs0[i]), std::ref(inputs1[i])));
+        }
+
+        // Now block on all of them one at a time.
+        std::vector<std::tuple<vector<vector<VoxelMatch>>, vector<vector<VoxelPair>>, vector<vector<VoxelPair>>>> pairResults;
+        for (auto& future : resultFutures) {
+            pairResults.push_back(future.get());
+        }
+
+        vector<BettiMatchingResult> arrayResults;
+
+        // Write the results into numpy arrays
+        for (auto &result : pairResults) {
+            auto matchesByDimension = std::get<0>(result);
+            auto predictionUnmatchedByDimension = std::get<1>(result);
+
+            size_t numMatches = 0;
+            size_t numPredictionUnmatched = 0;
+            for (size_t d = 0; d < numDimensions; d++) {
+                numMatches += matchesByDimension[d].size();
+                numPredictionUnmatched += predictionUnmatchedByDimension[d].size();
+            }
+
+            // Shape (num matched in total, num dimensions)
+            py::array_t<int64_t> predictionMatchesBirthCoordinates({numMatches, numDimensions}, {numDimensions * sizeof(int64_t), sizeof(int64_t)});
+            py::array_t<int64_t> predictionMatchesDeathCoordinates({numMatches, numDimensions}, {numDimensions * sizeof(int64_t), sizeof(int64_t)});
+            py::array_t<int64_t> targetMatchesBirthCoordinates({numMatches, numDimensions}, {numDimensions * sizeof(int64_t), sizeof(int64_t)});
+            py::array_t<int64_t> targetMatchesDeathCoordinates({numMatches, numDimensions}, {numDimensions * sizeof(int64_t), sizeof(int64_t)});
+            // Shape (num unmatched (prediction) in total, num dimensions)
+            py::array_t<int64_t> predictionUnmatchedBirthCoordinates({numPredictionUnmatched, numDimensions}, {numDimensions * sizeof(int64_t), sizeof(int64_t)});
+            py::array_t<int64_t> predictionUnmatchedDeathCoordinates({numPredictionUnmatched, numDimensions}, {numDimensions * sizeof(int64_t), sizeof(int64_t)});
+            // Shape (num dimensions,)
+            py::array_t<int64_t> numMatchesByDim({numDimensions}, {sizeof(int64_t)});
+            py::array_t<int64_t> numUnmatchedPredictionByDim({numDimensions}, {sizeof(int64_t)});
+
+            auto predictionMatchesBirthCoordinatesView = predictionMatchesBirthCoordinates.mutable_unchecked();
+            auto predictionMatchesDeathCoordinatesView = predictionMatchesDeathCoordinates.mutable_unchecked();
+            auto targetMatchesBirthCoordinatesView = targetMatchesBirthCoordinates.mutable_unchecked();
+            auto targetMatchesDeathCoordinatesView = targetMatchesDeathCoordinates.mutable_unchecked();
+            auto predictionUnmatchedBirthCoordinatesView = predictionUnmatchedBirthCoordinates.mutable_unchecked();
+            auto predictionUnmatchedDeathCoordinatesView = predictionUnmatchedDeathCoordinates.mutable_unchecked();
+            auto numMatchesByDimView = numMatchesByDim.mutable_unchecked();
+            auto numUnmatchedPredictionByDimView = numUnmatchedPredictionByDim.mutable_unchecked();
+
+            int i = 0;
+            int currentDimension = 0;
+            for (auto &matchesInDimension : matchesByDimension) {
+                for (auto &match : matchesInDimension) {
+                    for (int d = 0; d < numDimensions; d++) {
+                        predictionMatchesBirthCoordinatesView(i, d) = match.pair0.birth[d];
+                        predictionMatchesDeathCoordinatesView(i, d) = match.pair0.death[d];
+                        targetMatchesBirthCoordinatesView(i, d) = match.pair1.birth[d];
+                        targetMatchesDeathCoordinatesView(i, d) = match.pair1.death[d];
+                    }
+                    i += 1;
+                }
+                numMatchesByDimView(currentDimension) = matchesInDimension.size();
+                currentDimension++;
+            }
+            i = 0;
+            currentDimension = 0;
+            for (auto &unmatchedInDimension : predictionUnmatchedByDimension) {
+                for (auto &unmatched : unmatchedInDimension) {
+                    for (int d = 0; d < numDimensions; d++) {
+                        predictionUnmatchedBirthCoordinatesView(i, d) = unmatched.birth[d];
+                        predictionUnmatchedDeathCoordinatesView(i, d) = unmatched.death[d];
+                    }
+                    i += 1;
+                }
+                numUnmatchedPredictionByDimView(currentDimension) = unmatchedInDimension.size();
+                currentDimension += 1;
+            }
+
+            arrayResults.emplace_back(BettiMatchingResult{
+                std::move(predictionMatchesBirthCoordinates),
+                std::move(predictionMatchesDeathCoordinates),
+                std::move(targetMatchesBirthCoordinates),
+                std::move(targetMatchesDeathCoordinates),
+                std::move(predictionUnmatchedBirthCoordinates),
+                std::move(predictionUnmatchedDeathCoordinates),
+                std::move(numMatchesByDim),
+                std::move(numUnmatchedPredictionByDim)});
+        }
+        return arrayResults;
     });
 
-
-    m.def("compute_matching", [](string input0_path, string input1_path) {
-        vector<value_t> input0Vector;
-        vector<value_t> input1Vector;
-        vector<index_t> shape0;
-        vector<index_t> shape1;
-        readImage(input0_path, NUMPY, input0Vector, shape0);
-        readImage(input1_path, NUMPY, input1Vector, shape1);
-        if (shape0 != shape1) {
-            throw invalid_argument("The shapes of the tree input volumes must agree. Got " + repr_vector(shape0)
-                                    + " and " + repr_vector(shape1));
-        }
-        Config config;
-        BettiMatching BM(std::move(input0Vector), std::move(input1Vector), std::move(shape0), std::move(config));
-        BM.computeMatching();
-        return BM.getMatching();
-    });
 
 
     py::class_<VoxelMatch>(m, "VoxelMatch")
@@ -117,5 +217,32 @@ PYBIND11_MODULE(betti_matching, m) {
         .def("__repr__", [](VoxelPair &self) {
           return "VoxelPair(birth=" + repr_vector(self.birth) +
                  ", death=" + repr_vector(self.death) + ")";
+        });
+
+    auto resultTypesModule = m.def_submodule("return_types", "Return types for betti_matching");
+
+    py::class_<BettiMatchingResult>(resultTypesModule, "BettiMatchingResult")
+        .def_readonly("prediction_matches_birth_coordinates", &BettiMatchingResult::predictionMatchesBirthCoordinates)
+        .def_readonly("prediction_matches_death_coordinates", &BettiMatchingResult::predictionMatchesDeathCoordinates)
+        .def_readonly("target_matches_birth_coordinates", &BettiMatchingResult::targetMatchesBirthCoordinates)
+        .def_readonly("target_matches_death_coordinates", &BettiMatchingResult::targetMatchesDeathCoordinates)
+        .def_readonly("prediction_unmatched_birth_coordinates", &BettiMatchingResult::predictionUnmatchedBirthCoordinates)
+        .def_readonly("prediction_unmatched_death_coordinates", &BettiMatchingResult::predictionUnmatchedDeathCoordinates)
+        .def_readonly("num_matches_by_dim", &BettiMatchingResult::numMatchesByDim)
+        .def_readonly("num_unmatched_prediction_by_dim", &BettiMatchingResult::numUnmatchedPredictionByDim)
+        .def("__repr__", [](BettiMatchingResult &self) {
+            auto reprMemberArray = [](string name, py::array_t<int64_t>& array) {
+                return name + "=" + repr_vector(std::vector<index_t>(array.shape(), array.shape() + array.ndim()), make_tuple("[", "]"));
+            };
+            return "BettiMatchingResult(" + (
+                reprMemberArray("prediction_matches_birth_coordinates", self.predictionMatchesBirthCoordinates) + ", " +
+                reprMemberArray("prediction_matches_death_coordinates", self.predictionMatchesDeathCoordinates) + ", " +
+                reprMemberArray("target_matches_birth_coordinates", self.targetMatchesBirthCoordinates) + ", " +
+                reprMemberArray("target_matches_death_coordinates", self.targetMatchesDeathCoordinates) + ", " +
+                reprMemberArray("prediction_unmatched_birth_coordinates", self.predictionUnmatchedBirthCoordinates) + ", " +
+                reprMemberArray("prediction_unmatched_death_coordinates", self.predictionUnmatchedDeathCoordinates) + ", " +
+                reprMemberArray("num_matches_by_dim", self.numMatchesByDim) + ", " +
+                reprMemberArray("num_unmatched_prediction_by_dim", self.numUnmatchedPredictionByDim)
+            ) + ")";
         });
 }

--- a/src/config.h
+++ b/src/config.h
@@ -12,9 +12,10 @@
 //#define USE_APPARENT_PAIRS
 #define USE_EMERGENT_PAIRS
 #define USE_CACHE
-#define USE_CLEARING_IMAGE
+//#define USE_CLEARING_IMAGE
 #define USE_CLEARING_DIM0
 #define USE_STABLE_SORT_OR_STABLE_PARTITION // enables stable sort/binary input sorting optimization in dim3 edge enumeration methods
+#define PARALLELIZE_INDEPENDENT_BARCODES_DIM1 // enables parallelization of independent barcode computations in dim3::Dimension1
 
 typedef uint32_t index_t;
 typedef double value_t;
@@ -26,6 +27,9 @@ enum fileFormat { DIPHA, PERSEUS, NUMPY };
 
 using namespace std;
 
+#if defined(PARALLELIZE_INDEPENDENT_BARCODES_DIM1) and defined(USE_CLEARING_IMAGE)
+	static_assert(false, "PARALLELIZE_INDEPENDENT_BARCODES_DIM1 is active alongside incompatible options (race conditions could occur!)");
+#endif
 
 
 struct Config {

--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,7 @@
 #define USE_CACHE
 #define USE_CLEARING_IMAGE
 #define USE_CLEARING_DIM0
+#define USE_STABLE_SORT_OR_STABLE_PARTITION // enables stable sort/binary input sorting optimization in dim3 edge enumeration methods
 
 typedef uint32_t index_t;
 typedef double value_t;

--- a/src/src_3D/dimension_0.cpp
+++ b/src/src_3D/dimension_0.cpp
@@ -190,18 +190,34 @@ void Dimension0::enumerateEdges(vector<Cube>& edges, const CubicalGridComplex& c
 #ifdef USE_CLEARING_DIM0
 	Cube cube;
 #endif
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+	bool binaryInputs = true;
+#endif
 	for (index_t x = 0; x < cgc.shape[0]; ++x) {
 		for (index_t y = 0; y < cgc.shape[1]; ++y) {
 			for (index_t z = 0; z < cgc.shape[2]; ++z) {
 				for (uint8_t type = 0; type < 3; ++type) {
 					birth = cgc.getBirth(x, y, z, type, 1);
-					if (birth < config.threshold) { edges.push_back(Cube(birth, x, y, z, type)); }	
+					if (birth < config.threshold) {
+						edges.push_back(Cube(birth, x, y, z, type));
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+						if (binaryInputs && birth != 0 && birth != 1) binaryInputs = false;
+#endif
+					}	
 				}				
 			}
 		}
 	}
 
-	sort(edges.begin(), edges.end(), CubeComparator());
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+	if (binaryInputs) {
+		std::stable_partition(edges.begin(), edges.end(), [](Cube &cube) { return cube.birth == 0; });
+	} else {
+		std::stable_sort(edges.begin(), edges.end(), [](const Cube &cube1, const Cube &cube2) { return cube1.birth < cube2.birth; });
+	}
+#else
+	std::sort(edges.begin(), edges.end(), CubeComparator());
+#endif
 
 #ifdef RUNTIME
 	auto stop = high_resolution_clock::now();

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -1,9 +1,10 @@
 #include "dimension_1.h"
 #include "enumerators.h"
 
-#include <iostream>
-#include <chrono>
 #include <algorithm>
+#include <chrono>
+#include <future>
+#include <iostream>
 #include <stdexcept>
 
 using namespace dim3;
@@ -29,60 +30,92 @@ Dimension1::Dimension1(const CubicalGridComplex& _cgc0, const CubicalGridComplex
 
 
 void Dimension1::computePairsAndMatch(vector<Cube>& ctr0, vector<Cube>& ctr1, vector<Cube>& ctrComp, vector<Cube>& ctrImage) {
+	auto processInput0 = [this, &ctr0]() {
 #ifdef RUNTIME
-	cout << endl << "input 0: ";
+		cout << endl << "input 0: ";
 #endif
-
-	computePairs(ctr0, 0);
+    	computePairs(ctr0, 0);
 #ifdef USE_CLEARING_DIM0
-	enumerateEdges(ctr0, cgc0, pivotColumnIndexInput0);
+    	enumerateEdges(ctr0, cgc0, pivotColumnIndexInput0);
 #endif
+	};
 
+	auto processInput1 = [this, &ctr1]() {
 #ifdef RUNTIME
-	cout << endl << "input 1: ";
+    	cout << endl << "input 1: ";
 #endif
 
-	computePairs(ctr1, 1);
+	    computePairs(ctr1, 1);
 #ifdef USE_CLEARING_DIM0
-	enumerateEdges(ctr1, cgc1, pivotColumnIndexInput1);
+    	enumerateEdges(ctr1, cgc1, pivotColumnIndexInput1);
 #endif
+	};
 
+	auto processComparison = [this, &ctrComp, &ctrImage]() {
 #ifdef RUNTIME
-	cout << endl << "comparison: ";
+    	cout << endl << "comparison: ";
 #endif
 
-	computePairsComp(ctrComp);
+	    computePairsComp(ctrComp);
 #ifdef USE_CLEARING_DIM0
 #ifndef USE_APPARENT_PAIRS_COMP
-	ctrImage = ctrComp;
+    	ctrImage = ctrComp;
 #endif
-	enumerateEdges(ctrComp, cgcComp, pivotColumnIndexComp);
+	    enumerateEdges(ctrComp, cgcComp, pivotColumnIndexComp);
 #endif
+	};
 
+	auto processImageInput0Comparison = [this, &ctrComp, &ctrImage]() {
 #ifdef RUNTIME
-	cout << endl << "image 0: ";
+    	cout << endl << "image 0: ";
 #endif
 
 #if defined(USE_APPARENT_PAIRS_COMP) or defined(USE_CLEARING_DIM0)
-	computePairsImage(ctrImage, 0);
+    	computePairsImage(ctrImage, 0);
 #else
-	computePairsImage(ctrComp, 0);
+    	computePairsImage(ctrComp, 0);
 #endif
+	};
 
+	auto processImageInput1Comparison = [this, &ctrComp, &ctrImage]() {
 #ifdef RUNTIME
-	cout << endl << "image 1: ";
+		cout << endl << "image 1: ";
 #endif
 
 #if defined(USE_APPARENT_PAIRS_COMP) or defined(USE_CLEARING_DIM0)
-	computePairsImage(ctrImage, 1);
+          computePairsImage(ctrImage, 1);
 #else
-	computePairsImage(ctrComp, 1); 
+          computePairsImage(ctrComp, 1);
 #endif
-	
+	};
+
+#ifdef PARALLELIZE_INDEPENDENT_BARCODES_DIM1
+	auto comparisonFuture = std::async(processComparison);
+	auto input0Future = std::async(processInput0);
+	auto input1Future = std::async(processInput1);
+#if defined(USE_APPARENT_PAIRS_COMP) or defined(USE_CLEARING_DIM0) or defined(USE_ISPAIRED)
+	comparisonFuture.wait();
+#endif
+	auto imageInput0ComparisonFuture = std::async(processImageInput0Comparison);
+	auto imageInput1ComparisonFuture = std::async(processImageInput1Comparison);
+	input0Future.wait();
+	input1Future.wait();
+	imageInput0ComparisonFuture.wait();
+	imageInput1ComparisonFuture.wait();
+#if not(defined(USE_APPARENT_PAIRS_COMP) or defined(USE_CLEARING_DIM0) or defined(USE_ISPAIRED))
+	comparisonFuture.wait();
+#endif
+#else
+	processInput0();
+	processInput1();
+	processComparison();
+	processImageInput0Comparison();
+	processImageInput1Comparison();
+#endif
+
 #ifdef RUNTIME
 	cout << endl << "matching: ";
 #endif
-
 	computeMatching();
 }
 

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -698,25 +698,25 @@ void Dimension1::computePairsUnified(vector<Cube>& ctr, uint8_t k) {
 					continue;
 				} else {
 					pivotColumnIndex.emplace(pivot.index, i);
-					if (pivot.birth != ctr[i].birth) {
-                        if (computePairsMode == INPUT_PAIRS || computePairsMode == COMPARISON_PAIRS) {
+					if (computePairsMode == INPUT_PAIRS || computePairsMode == COMPARISON_PAIRS) {
+						if (pivot.birth != ctr[i].birth) {
 							pairs.push_back(Pair(pivot, ctr[i]));
+							if (computePairsMode == INPUT_PAIRS) {
+								matchMap.emplace(pivot.index, pairs.back());
+							}
+#ifdef USE_ISPAIRED
+							if (computePairsMode == COMPARISON_PAIRS) {
+								isPairedComp.emplace(ctr[i].index, true);
+							}
+#endif
 						}
-                        if (computePairsMode == INPUT_PAIRS) { 
-						    matchMap.emplace(pivot.index, pairs.back());
-                        }
-                        if (computePairsMode == COMPARISON_PAIRS) {
+					}
+					if (computePairsMode == IMAGE_PAIRS
 #ifdef USE_ISPAIRED
-    						isPairedComp.emplace(ctr[i].index, true);
+						&& isPairedComp[ctr[i].index]
 #endif
-                        }
-                        if (computePairsMode == IMAGE_PAIRS
-#ifdef USE_ISPAIRED
-						 	&& isPairedComp[ctr[i].index]
-#endif
-						) {
-                            matchMapIm.emplace(ctr[i].index, pivot.index);
-                        }
+					) {
+						matchMapIm.emplace(ctr[i].index, pivot.index);
 					}
 #ifdef USE_CACHE
 					if (numRecurse >= config.minRecursionToCache) {

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -565,18 +565,6 @@ void Dimension1::computePairsUnified(vector<Cube>& ctr, uint8_t k) {
 #else
         false;
 #endif
-    const bool useEmergentPairs = 
-#ifdef USE_EMERGENT_PAIRS
-        true;
-#else
-        false;
-#endif
-    const bool useIsPaired = 
-#ifdef USE_ISPAIRED
-        true;
-#else
-        false;
-#endif
 
 	size_t ctrSize = ctr.size();
 	pivotColumnIndex.clear();
@@ -710,7 +698,9 @@ void Dimension1::computePairsUnified(vector<Cube>& ctr, uint8_t k) {
 				} else {
 					pivotColumnIndex.emplace(pivot.index, i);
 					if (pivot.birth != ctr[i].birth) {
-						pairs.push_back(Pair(pivot, ctr[i]));
+                        if (computePairsMode == INPUT_PAIRS || computePairsMode == COMPARISON_PAIRS) {
+							pairs.push_back(Pair(pivot, ctr[i]));
+						}
                         if (computePairsMode == INPUT_PAIRS) { 
 						    matchMap.emplace(pivot.index, pairs.back());
                         }

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -279,6 +279,9 @@ void Dimension1::enumerateEdges(vector<Cube>& edges, const CubicalGridComplex& c
 #ifdef USE_CLEARING_DIM0
 	Cube cube;
 #endif
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+	bool binaryInputs = true;
+#endif
 	for (index_t x = 0; x < cgc.shape[0]; ++x) {
 		for (index_t y = 0; y < cgc.shape[1]; ++y) {
 			for (index_t z = 0; z < cgc.shape[2]; ++z) {
@@ -288,17 +291,33 @@ void Dimension1::enumerateEdges(vector<Cube>& edges, const CubicalGridComplex& c
 #ifdef USE_CLEARING_DIM0
 						cube = Cube(birth, x, y, z, type);
 						auto find = pivotColumnIndex.find(cube.index);
-						if (!find.has_value()) { edges.push_back(cube); }
+						if (!find.has_value())
+						{
+							edges.push_back(cube);
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+							if (binaryInputs && birth != 0 && birth != 1) binaryInputs = false;
+#endif
+						}
 #else
 						edges.push_back(Cube(birth, x, y, z, type));
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+						if (binaryInputs && birth != 0 && birth != 1) binaryInputs = false;
+#endif
 #endif
 					}	
 				}				
 			}
 		}
 	}
-
-	sort(edges.begin(), edges.end(), CubeComparator());
+#ifdef USE_STABLE_SORT_OR_STABLE_PARTITION
+	if (binaryInputs) {
+		std::stable_partition(edges.begin(), edges.end(), [](Cube &cube) { return cube.birth == 0; });
+	} else {
+		std::stable_sort(edges.begin(), edges.end(), [](const Cube &cube1, const Cube &cube2) { return cube1.birth < cube2.birth; });
+	}
+#else
+	std::sort(edges.begin(), edges.end(), CubeComparator());
+#endif
 
 #ifdef RUNTIME
 	auto stop = high_resolution_clock::now();

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -610,10 +610,6 @@ void Dimension1::computePairsUnified(vector<Cube>& ctr, uint8_t k) {
 	vector<Cube> faces;
 	BoundaryEnumerator enumeratorAP(cgc);
 	CoboundaryEnumerator coEnumeratorAP(cgc);
-    // if ((computePairsMode == INPUT_PAIRS && useApparentPairs) || (computePairsMode == COMPARISON_PAIRS && useApparentPairsComp) || useEmergentPairs) {
-    //     if (computePairsMode == INPUT_PAIRS || computePairsMode == COMPARISON_PAIRS) {
-    //     }
-    // }
 	bool shouldClear;
     if (computePairsMode == COMPARISON_PAIRS) {
 #if defined (USE_CLEARING_IMAGE) and not defined(USE_APPARENT_PAIRS_COMP)

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -20,7 +20,7 @@ Dimension1::Dimension1(const CubicalGridComplex& _cgc0, const CubicalGridComplex
 #ifdef USE_REDUCTION_MATRIX
 						reductionMatrix(_cgc0.shape),
 #endif
-						pivotColumnIndex(_cgc0.shape) {}
+						pivotColumnIndex(_cgc0.shape), cache(_cgc0.shape) {}
 
 
 void Dimension1::computePairsAndMatch(vector<Cube>& ctr0, vector<Cube>& ctr1, vector<Cube>& ctrComp, vector<Cube>& ctrImage) {
@@ -100,7 +100,6 @@ vector<vector<index_t>> Dimension1::getRepresentativeCycle(const Pair& pair, con
 #endif
 #ifdef USE_CACHE
 	cache.clear();
-	cache.reserve(min(config.cacheSize, ctrSize));
 	queue<uint64_t> cachedColumnIdx;
 	size_t numRecurse;
 #endif
@@ -387,30 +386,28 @@ void Dimension1::useReductionMatrix(const Cube& column, CubeQueue& workingBounda
 
 #ifdef USE_CACHE
 bool Dimension1::columnIsCached(const Cube& column, CubeQueue& workingBoundary) const {
-	auto pair = cache.find(column.index);
-	if (pair != cache.end()) {
-		auto cachedBoundary = pair->second;
-		while (!cachedBoundary.empty()) {
-			workingBoundary.push(cachedBoundary.top());
-			cachedBoundary.pop();
+	auto& cachedBoundary = cache.find(column.index);
+	if (cachedBoundary.has_value()) {
+		for (auto &face : *cachedBoundary) {
+			workingBoundary.push(face);
 		}
 		return true;
 	} else { return false; }
 }
 
 void Dimension1::addCache(const Cube& column, CubeQueue& workingBoundary, queue<uint64_t>& cachedColumnIdx) {
-	CubeQueue cleanWb;
-	Cube c;
+	std::vector<Cube> cleanWb;
 	while (!workingBoundary.empty()) {
-		c = workingBoundary.top();
+		Cube c = workingBoundary.top();
 		workingBoundary.pop();
 		if (!workingBoundary.empty() && c == workingBoundary.top()) { workingBoundary.pop(); } 
-		else { cleanWb.push(c); }
+		else { cleanWb.emplace_back(c); }
 	}
-	cache.emplace(column.index, cleanWb);
+
+	cache[column.index] = std::move(cleanWb);
 	cachedColumnIdx.push(column.index);
 	if (cachedColumnIdx.size() > config.cacheSize) {
-		cache.erase(cachedColumnIdx.front());
+		cache[cachedColumnIdx.front()] = {};
 		cachedColumnIdx.pop();
 	}
 }
@@ -556,7 +553,6 @@ void Dimension1::computePairsUnified(vector<Cube>& ctr, uint8_t k) {
 #endif
 #ifdef USE_CACHE
 	cache.clear();
-	cache.reserve(min(config.cacheSize, ctrSize));
 	queue<uint64_t> cachedColumnIdx;
 	size_t numRecurse;
 #ifdef RUNTIME

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -739,39 +739,25 @@ void Dimension1::computePairsUnified(vector<Cube>& ctr, uint8_t k) {
 					break;
 				}
 			} else {
-                if (computePairsMode == COMPARISON_PAIRS) {
-#if defined(USE_CLEARING_IMAGE) and not defined(USE_APPARENT_PAIRS_COMP)
-                    ctr[i].index = NONE;
-                    shouldClear = true;
-#endif
-                }
-                if (computePairsMode == IMAGE_PAIRS) {
 #if defined(USE_CLEARING_IMAGE)
+                if ((computePairsMode == COMPARISON_PAIRS && !useApparentPairsComp) || computePairsMode == IMAGE_PAIRS) {
                     ctr[i].index = NONE;
                     shouldClear = true;
-#endif
                 }
+#endif
                 break;
             }
 		}
 	}
 
-if (computePairsMode == COMPARISON_PAIRS) {
-#if defined(USE_CLEARING_IMAGE) and not defined(USE_APPARENT_PAIRS_COMP)
-	if (shouldClear) {
-		auto newEnd = remove_if(ctr.begin(), ctr.end(), [](const Cube& cube) { return cube.index == NONE; });
-		ctr.erase(newEnd, ctr.end());
+#if defined(USE_CLEARING_IMAGE)
+	if ((computePairsMode == COMPARISON_PAIRS && !useApparentPairsComp) || computePairsMode == IMAGE_PAIRS) {
+		if (shouldClear) {
+			auto newEnd = remove_if(ctr.begin(), ctr.end(), [](const Cube& cube) { return cube.index == NONE; });
+			ctr.erase(newEnd, ctr.end());
+		}
 	}
 #endif
-}
-if (computePairsMode == IMAGE_PAIRS) {
-#ifdef USE_CLEARING_IMAGE
-	if (shouldClear) {
-		auto newEnd = remove_if(ctr.begin(), ctr.end(), [](const Cube& cube) { return cube.index == NONE; });
-		ctr.erase(newEnd, ctr.end());
-	}
-#endif
-}
 
 #ifdef RUNTIME
 	auto stop = high_resolution_clock::now();

--- a/src/src_3D/dimension_1.cpp
+++ b/src/src_3D/dimension_1.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <chrono>
 #include <algorithm>
+#include <stdexcept>
 
 using namespace dim3;
 using namespace std::chrono;
@@ -486,7 +487,7 @@ template <Dimension1::ComputePairsMode computePairsMode>
 bool Dimension1::isEmergentPairUnified(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
 	const CubicalGridComplex& cgc, BoundaryEnumerator& enumerator, BoundaryEnumerator& enumeratorAP, 
 	CoboundaryEnumerator& coEnumeratorAP) const {
-		if (computePairsMode == ComputePairsMode::COMPARISON_PAIRS) {
+		if (computePairsMode == ComputePairsMode::INPUT_PAIRS) {
 			return isEmergentPair(column, pivot, j, faces, checkEmergentPair, enumerator, enumeratorAP, coEnumeratorAP);
 		}
 		if (computePairsMode == ComputePairsMode::COMPARISON_PAIRS) {
@@ -495,7 +496,7 @@ bool Dimension1::isEmergentPairUnified(const Cube&column, Cube& pivot, size_t& j
 		if (computePairsMode == ComputePairsMode::IMAGE_PAIRS) {
 			return isEmergentPairImage(column, pivot, j, faces, checkEmergentPair, cgc, enumerator);
 		}
-		return false; // never happens
+		throw runtime_error("Invalid template argument computePairsMode"); // never happens on valid usage
 	}
 #endif
 

--- a/src/src_3D/dimension_1.h
+++ b/src/src_3D/dimension_1.h
@@ -47,17 +47,8 @@ class Dimension1 {
 										BoundaryEnumerator& enumerator, CoboundaryEnumerator& coEnumerator) const;
 #endif
 #ifdef USE_EMERGENT_PAIRS
-	bool isEmergentPair(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
-						BoundaryEnumerator& enumerator, BoundaryEnumerator& enumeratorAP, 
-						CoboundaryEnumerator& coEnumeratorAP) const;
-	bool isEmergentPairComp(const Cube& column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair, 
-							BoundaryEnumerator& enumerator, BoundaryEnumerator& enumeratorAP, 
-							CoboundaryEnumerator& coEnumeratorAP) const; 
-	bool isEmergentPairImage(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
-								const CubicalGridComplex& cgc, BoundaryEnumerator& enumerator) const;
-
 	template <ComputePairsMode computePairsMode>
-	bool isEmergentPairUnified(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
+	bool isEmergentPair(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
 								const CubicalGridComplex& cgc, BoundaryEnumerator& enumerator, BoundaryEnumerator& enumeratorAP, 
 								CoboundaryEnumerator& coEnumeratorAP) const;
 #endif

--- a/src/src_3D/dimension_1.h
+++ b/src/src_3D/dimension_1.h
@@ -29,7 +29,7 @@ class Dimension1 {
 	template <ComputePairsMode computePairsMode>
 	void computePairsUnified(vector<Cube>& ctr, uint8_t k);
 	void computeMatching();
-	void enumerateEdges(vector<Cube>& edges, const CubicalGridComplex& cgc) const;
+	void enumerateEdges(vector<Cube>& edges, const CubicalGridComplex& cgc, CubeMap<1, size_t>& pivotColumnIndex) const;
 	void enumerateColumnsToReduce(vector<Cube>& ctr, const CubicalGridComplex& cgc) const;
 	Cube popPivot(CubeQueue& column) const;
 	Cube getPivot(CubeQueue& column) const;
@@ -50,7 +50,7 @@ class Dimension1 {
 	template <ComputePairsMode computePairsMode>
 	bool isEmergentPair(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
 								const CubicalGridComplex& cgc, BoundaryEnumerator& enumerator, BoundaryEnumerator& enumeratorAP, 
-								CoboundaryEnumerator& coEnumeratorAP) const;
+								CoboundaryEnumerator& coEnumeratorAP, CubeMap<1, size_t>& pivotColumnIndex) const;
 #endif
 	const CubicalGridComplex& cgc0;
 	const CubicalGridComplex& cgc1;
@@ -69,7 +69,12 @@ class Dimension1 {
 	CubeMap<1, Pair> matchMap1;
 	CubeMap<1, uint64_t> matchMapIm0;
 	CubeMap<1, uint64_t> matchMapIm1;
-	CubeMap<1, size_t> pivotColumnIndex;
+
+	CubeMap<1, size_t> pivotColumnIndexInput0; // to be used for input 0 pairs
+	CubeMap<1, size_t> pivotColumnIndexInput1; // to be used for input 1 pairs
+	CubeMap<1, size_t> pivotColumnIndexComp; // to be used for comparison pairs
+	CubeMap<1, size_t> pivotColumnIndexImage0; // to be used for image pairs 0
+	CubeMap<1, size_t> pivotColumnIndexImage1; // to be used for image pairs 1
 #ifdef USE_REDUCTION_MATRIX
 	CubeMap<2, vector<Cube>> reductionMatrix;
 #endif

--- a/src/src_3D/dimension_1.h
+++ b/src/src_3D/dimension_1.h
@@ -20,9 +20,14 @@ class Dimension1 {
 	vector<vector<index_t>> getRepresentativeCycle(const Pair& pair, const CubicalGridComplex& cgc);
 
 	private:
-	void computePairs(const vector<Cube>& ctr, uint8_t k);
+	enum ComputePairsMode { INPUT_PAIRS, COMPARISON_PAIRS, IMAGE_PAIRS };
+
+	void computePairs(vector<Cube>& ctr, uint8_t k);
 	void computePairsComp(vector<Cube>& ctr);
 	void computePairsImage(vector<Cube>& ctr, uint8_t k);
+
+	template <ComputePairsMode computePairsMode>
+	void computePairsUnified(vector<Cube>& ctr, uint8_t k);
 	void computeMatching();
 	void enumerateEdges(vector<Cube>& edges, const CubicalGridComplex& cgc) const;
 	void enumerateColumnsToReduce(vector<Cube>& ctr, const CubicalGridComplex& cgc) const;
@@ -50,6 +55,11 @@ class Dimension1 {
 							CoboundaryEnumerator& coEnumeratorAP) const; 
 	bool isEmergentPairImage(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
 								const CubicalGridComplex& cgc, BoundaryEnumerator& enumerator) const;
+
+	template <ComputePairsMode computePairsMode>
+	bool isEmergentPairUnified(const Cube&column, Cube& pivot, size_t& j, vector<Cube>& faces, bool& checkEmergentPair,
+								const CubicalGridComplex& cgc, BoundaryEnumerator& enumerator, BoundaryEnumerator& enumeratorAP, 
+								CoboundaryEnumerator& coEnumeratorAP) const;
 #endif
 	const CubicalGridComplex& cgc0;
 	const CubicalGridComplex& cgc1;

--- a/src/src_3D/dimension_1.h
+++ b/src/src_3D/dimension_1.h
@@ -65,13 +65,13 @@ class Dimension1 {
 #ifdef USE_ISPAIRED
 	unordered_map<uint64_t, bool> isPairedComp;
 #endif
-	unordered_map<uint64_t, Pair> matchMap0;
-	unordered_map<uint64_t, Pair> matchMap1;
-	unordered_map<uint64_t, uint64_t> matchMapIm0;
-	unordered_map<uint64_t, uint64_t> matchMapIm1;
-	unordered_map<uint64_t, size_t> pivotColumnIndex;
+	CubeMap<1, Pair> matchMap0;
+	CubeMap<1, Pair> matchMap1;
+	CubeMap<1, uint64_t> matchMapIm0;
+	CubeMap<1, uint64_t> matchMapIm1;
+	CubeMap<1, size_t> pivotColumnIndex;
 #ifdef USE_REDUCTION_MATRIX
-	unordered_map<uint64_t, vector<Cube>> reductionMatrix;
+	CubeMap<2, vector<Cube>> reductionMatrix;
 #endif
 #ifdef USE_CACHE
 	unordered_map<uint64_t, CubeQueue> cache;

--- a/src/src_3D/dimension_1.h
+++ b/src/src_3D/dimension_1.h
@@ -34,11 +34,15 @@ class Dimension1 {
 	Cube popPivot(CubeQueue& column) const;
 	Cube getPivot(CubeQueue& column) const;
 #ifdef USE_REDUCTION_MATRIX
-	void useReductionMatrix(const Cube& column, CubeQueue& workingBoundary, BoundaryEnumerator& enumerator) const;
+	void useReductionMatrix(const Cube& column, CubeQueue& workingBoundary, BoundaryEnumerator& enumerator
+#ifdef USE_CACHE
+							, CubeMap<2, vector<Cube>>& cache
+#endif
+							) const;
 #endif
 #ifdef USE_CACHE
-	bool columnIsCached(const Cube& column, CubeQueue& workingBoundary) const;
-	void addCache(const Cube& column, CubeQueue& workingBoundary, queue<uint64_t>& cachedColumnIdx);
+	bool columnIsCached(const Cube& column, CubeQueue& workingBoundary, CubeMap<2, vector<Cube>>& cache) const;
+	void addCache(const Cube& column, CubeQueue& workingBoundary, queue<uint64_t>& cachedColumnIdx, CubeMap<2, vector<Cube>>& cache);
 #endif
 #if defined(USE_APPARENT_PAIRS) or defined(USE_APPARENT_PAIRS_COMP)
 	bool pivotIsApparentPair(const Cube& pivot, vector<Cube>& faces, 
@@ -77,9 +81,6 @@ class Dimension1 {
 	CubeMap<1, size_t> pivotColumnIndexImage1; // to be used for image pairs 1
 #ifdef USE_REDUCTION_MATRIX
 	CubeMap<2, vector<Cube>> reductionMatrix;
-#endif
-#ifdef USE_CACHE
-	CubeMap<2, vector<Cube>> cache;
 #endif
 };
 }

--- a/src/src_3D/dimension_1.h
+++ b/src/src_3D/dimension_1.h
@@ -38,7 +38,7 @@ class Dimension1 {
 #endif
 #ifdef USE_CACHE
 	bool columnIsCached(const Cube& column, CubeQueue& workingBoundary) const;
-	void addCache(const Cube& column, CubeQueue& working_boundary, queue<uint64_t>& cachedColumnIdx);
+	void addCache(const Cube& column, CubeQueue& workingBoundary, queue<uint64_t>& cachedColumnIdx);
 #endif
 #if defined(USE_APPARENT_PAIRS) or defined(USE_APPARENT_PAIRS_COMP)
 	bool pivotIsApparentPair(const Cube& pivot, vector<Cube>& faces, 
@@ -74,7 +74,7 @@ class Dimension1 {
 	CubeMap<2, vector<Cube>> reductionMatrix;
 #endif
 #ifdef USE_CACHE
-	unordered_map<uint64_t, CubeQueue> cache;
+	CubeMap<2, vector<Cube>> cache;
 #endif
 };
 }


### PR DESCRIPTION
Implements several optimizations in dim3::Dimension1 that improve the runtime performance:

    replace unordered_maps indexed by cube indices by a flat vector-based data structure CubeMap
    use stable sort instead of CubeComparator in enumerate_edges; use stable partitioning for binary inputs arrays
    store cleaned working boundaries in cache as vectors, not priority queues
    parallelize independent barcode computations in Dimension1::computePairsAndMatch using std::async

Unifies the three barcode computation methods in dim3::Dimension1 into one template method.

Exposes a function via pybind that takes a batch of inputs, parallelizes over the batch elements, and collects the results into numpy arrays that can be used efficiently on the python side.